### PR TITLE
Suggest i/at instead of i/loc

### DIFF
--- a/dovpanda/config.py
+++ b/dovpanda/config.py
@@ -3,3 +3,8 @@ import pandas as pd
 READ_METHODS = [method for method in dir(pd) if 'read' in method]
 DF_CREATION = READ_METHODS + ['DataFrame.__init__']
 SERIES_CREATION = READ_METHODS + ['Series.__init__']
+GET_ITEM = ['DataFrame.__getitem__', 'Series.__getitem__',
+            'core.indexing._NDFrameIndexer.__getitem__', 'core.indexing._LocationIndexer.__getitem__']
+
+# Translation dict
+ndim_to_obj = {1: 'series', 2: 'df'}

--- a/dovpanda/core.py
+++ b/dovpanda/core.py
@@ -90,10 +90,14 @@ def csv_index(res, arguments):
 
 @ledger.add_hint(config.GET_ITEM, 'post')
 def suggest_at_iat(res, arguments):
+    self = arguments.get('self')
     shp = res.shape
+    if res.ndim < 1:  # Sometimes specific slicing will return value
+        return
+    i = 'i' if isinstance(self, type(res.iloc)) else ''  # Help the user with at and iat
     if all(dim == 1 for dim in shp):
         obj = config.ndim_to_obj.get(res.ndim, 'object')
         ledger.teller(f"The shape of the returned {obj} from slicing is {shp} "
                       f"Which suggests you are interested in the value and not "
                       f"in a new {obj}. Try instead: <br>"
-                      f"<code>{obj}.at[row, col]</code>")
+                      f"<code>{obj}.{i}at[row, col]</code>")

--- a/dovpanda/core.py
+++ b/dovpanda/core.py
@@ -1,4 +1,4 @@
-from dovpanda import base
+from dovpanda import base, config
 from dovpanda.base import Ledger
 
 ledger = Ledger()
@@ -86,3 +86,14 @@ def csv_index(res, arguments):
         if arguments.get('index_col') is None:
             ledger.tell('Your left most column is unnamed. This suggets it might be the index column, try: '
                         f'<code>pd.read_csv({filename}, index_col=0)</code>')
+
+
+@ledger.add_hint(config.GET_ITEM, 'post')
+def suggest_at_iat(res, arguments):
+    shp = res.shape
+    if all(dim == 1 for dim in shp):
+        obj = config.ndim_to_obj.get(res.ndim, 'object')
+        ledger.teller(f"The shape of the returned {obj} from slicing is {shp} "
+                      f"Which suggests you are interested in the value and not "
+                      f"in a new {obj}. Try instead: <br>"
+                      f"<code>{obj}.at[row, col]</code>")


### PR DESCRIPTION
- [x] closes #29 

# Description
When slicing to get one value (shape (1,1) or (1,)), suggest at instead of loc.